### PR TITLE
Add VPC endpoint for S3 

### DIFF
--- a/embeddings/dask/.gitignore
+++ b/embeddings/dask/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+*.hcl
+*.tfstate
+*.tfstate.*

--- a/embeddings/dask/cluster.sh
+++ b/embeddings/dask/cluster.sh
@@ -4,7 +4,7 @@ set -uex
 set -o pipefail
 
 CLUSTER=dask
-EXISTS=$(eksctl get cluster | grep "$CLUSTER" || echo -n "Not found")
+EXISTS=$(eksctl get cluster --region us-east-2 | grep "$CLUSTER" || echo -n "Not found")
 
 if [ "$EXISTS" == "Not found" ]; then
     # create cluster with fargate backend

--- a/embeddings/dask/cluster.sh
+++ b/embeddings/dask/cluster.sh
@@ -30,3 +30,8 @@ if [ "$EXISTS" == "Not found" ]; then
         --region us-east-2
 fi
 
+VPC_ID=`eksctl get cluster --region us-east-2 --name dask -o json | jq -r '.[].ResourcesVpcConfig.VpcId'`
+export TF_VAR_vpc_id=$VPC_ID
+
+terraform init
+terraform apply

--- a/embeddings/dask/vpc.tf
+++ b/embeddings/dask/vpc.tf
@@ -1,0 +1,63 @@
+provider "aws" {
+  region = local.region
+}
+
+variable "vpc_id" {}
+
+locals {
+  name   = "dask"
+  region = "us-east-2"
+
+  tags = {
+    Owner = "Ivan"
+  }
+}
+
+data "aws_subnets" "eks_vpc" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+}
+
+data "aws_subnet" "eks_subnet" {
+  for_each = toset(data.aws_subnets.eks_vpc.ids)
+  id       = each.value
+}
+
+
+locals {
+  private_subnet_ids = [for s in data.aws_subnet.eks_subnet : s.id if can(regex("private", lower(s.tags["Name"])))]
+}
+
+data "aws_route_table" "private" {
+  for_each  = toset(local.private_subnet_ids)
+  subnet_id = each.key
+}
+
+locals {
+  private_route_tables_ids = [for t in data.aws_route_table.private : t.id]
+}
+
+data "aws_vpc" "eks" {
+  id = var.vpc_id
+}
+
+module "vpc_endpoints" {
+  source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  vpc_id = data.aws_vpc.eks.id
+
+  endpoints = {
+    s3 = {
+      service_type    = "Gateway"
+      service         = "s3"
+      route_table_ids = local.private_route_tables_ids
+      tags            = { Name = "s3-vpc-endpoint" }
+    },
+  }
+
+  tags = merge(local.tags, {
+    Project  = "Secret"
+    Endpoint = "true"
+  })
+}


### PR DESCRIPTION
To skip routing traffic to S3 through S3 I prepared terraform script which adds [VPC endpoint](https://docs.aws.amazon.com/vpc/latest/privatelink/gateway-endpoints.html) to VPC where cluster is running.